### PR TITLE
Added filtering for significance

### DIFF
--- a/aragwas_server/gwasdb/elastic.py
+++ b/aragwas_server/gwasdb/elastic.py
@@ -224,7 +224,6 @@ def filter_association_search(s, filters):
                     maf_filters.append(Q('range', maf={'gt':float(maf[0])/100}))
         s = s.filter(Q('bool',should = maf_filters))
     if 'mac' in filters and len(filters['mac']) == 1:
-        print(filters['mac'])
         if filters['mac'][0] == '0':
             s = s.filter('range', mac={'lte': 5})
         else:
@@ -244,6 +243,11 @@ def filter_association_search(s, filters):
         s = s.filter('range', snp__position={'gte': int(filters['start'])})
     if 'end' in filters:
         s = s.filter('range', snp__position={'lte': int(filters['end'])})
+    if 'significant' in filters:
+        if filters['significant'][0] == "b":
+            s = s.filter('term', overBonferroni='T')
+        elif filters['significant'][0] == "p":
+            s = s.filter('term', overFDR='T') #TODO: ONCE THE PERM THRESHOLDS ARE ADDED, CHANGE THIS TO overPermutation
     return s
 
 def get_aggregated_filtered_statistics(filters):

--- a/aragwas_server/gwasdb/rest.py
+++ b/aragwas_server/gwasdb/rest.py
@@ -66,9 +66,13 @@ def _get_percentages_from_buckets(buckets):
     out_dict = {}
     annos_dict = {'NON_SYNONYMOUS_CODING': 'ns', 'SYNONYMOUS_CODING': 's', 'INTERGENIC': 'i', 'INTRON': 'in'}
     tot_sum = sum(i['doc_count'] for i in buckets)
-    for i in buckets:
-        out_dict[annos_dict[i['key']] if i['key'] in annos_dict else str(i['key'])] = float(
-            i['doc_count']) / tot_sum
+    if tot_sum == 0:
+        for i in buckets:
+            out_dict[annos_dict[i['key']] if i['key'] in annos_dict else str(i['key'])] = 0
+    else:
+        for i in buckets:
+            out_dict[annos_dict[i['key']] if i['key'] in annos_dict else str(i['key'])] = float(
+                i['doc_count']) / tot_sum
     return out_dict
 
 def _is_filter_whole_dataset(filters):

--- a/aragwas_ui/src/components/geneDetail.vue
+++ b/aragwas_ui/src/components/geneDetail.vue
@@ -85,8 +85,8 @@
         type = ["genic", "non-genic"];
         chr = ["1", "2","3","4","5"];
         hideFields = [];
-        showControls = ["maf","annotation","type", "pageSize","mac"];
-        filters = {chr: this.chr, annotation: this.annotation, maf: this.maf, mac: this.mac, type: this.type};
+        showControls = ["maf","annotation","type", "pageSize","mac","significant"];
+        filters = {chr: this.chr, annotation: this.annotation, maf: this.maf, mac: this.mac, type: this.type, significant: "0"};
         deboundedLoadGenes = _.debounce(this.loadGenesInRegion, 300);
 
         get startRegion(): number  {

--- a/aragwas_ui/src/components/phenotypeDetail.vue
+++ b/aragwas_ui/src/components/phenotypeDetail.vue
@@ -126,8 +126,8 @@
       type = ["genic", "non-genic"];
       chr = ["1", "2","3","4","5"];
       hideFields = ["phenotype"];
-      showControls = ["chr","maf","annotation","type","mac"];
-      filters = {chr: this.chr, annotation: this.annotation, maf: this.maf, mac: this.mac, type: this.type};
+      showControls = ["chr","maf","annotation","type","mac","significant"];
+      filters = {chr: this.chr, annotation: this.annotation, maf: this.maf, mac: this.mac, type: this.type, significant: "p"};
       phenotypeView = {name: "phenotype", phenotypeId: this.id, controlPosition: "right"};
 
 

--- a/aragwas_ui/src/components/studyDetail.vue
+++ b/aragwas_ui/src/components/studyDetail.vue
@@ -172,8 +172,8 @@
       type = ["genic", "non-genic"];
       chr = ["1", "2","3","4","5"];
       hideFields = ["phenotype", "study"];
-      showControls = ["chr","maf","annotation","type","mac"];
-      filters = {chr: this.chr, annotation: this.annotation, maf: this.maf, mac: this.mac, type: this.type};
+      showControls = ["chr","maf","annotation","type","mac", "significant"];
+      filters = {chr: this.chr, annotation: this.annotation, maf: this.maf, mac: this.mac, type: this.type, significant: "p"};
       phenotypeView = {name: "study", studyId: this.id, controlPosition: "right"};
 
       @Watch("id")

--- a/aragwas_ui/src/components/topAssociations.vue
+++ b/aragwas_ui/src/components/topAssociations.vue
@@ -47,8 +47,8 @@
         annotation = ["ns", "s", "in", "i"];
         type = ["genic", "non-genic"];
         hideFields = [];
-        filters = {chr: this.chr, annotation: this.annotation, maf: this.maf, mac: this.mac, type: this.type};
-        showControls = ["maf","chr","annotation","type","mac"];
+        filters = {chr: this.chr, annotation: this.annotation, maf: this.maf, mac: this.mac, type: this.type, significant: "p"};
+        showControls = ["maf","chr","annotation","type","mac", "significant"];
         test = 'chr2:122242';
 
         tourOptions = {

--- a/aragwas_ui/src/components/topGenes.vue
+++ b/aragwas_ui/src/components/topGenes.vue
@@ -21,10 +21,11 @@
                                     label="Only count significant hits"
                                     v-model="significant"
                                     primary
+                                    class="mt-0 mb-0"
                             ></v-switch>
                             <div class="ml-3" v-if="significant">
-                                <v-radio label="Permutation threshold" v-model="threshold" value="p"></v-radio>
-                                <v-radio label="Bonferroni threshold" v-model="threshold" value="b"></v-radio>
+                                <v-radio label="Permutation threshold" v-model="threshold" value="p" class="mt-0 mb-0"></v-radio>
+                                <v-radio label="Bonferroni threshold" v-model="threshold" value="b" class="mt-0 mb-0"></v-radio>
                             </div>
                             <div>If turned off, all associations with p-value < 10<sup>-4</sup> will be taken into account.</div>
                         </div>

--- a/aragwas_ui/src/components/topasso.vue
+++ b/aragwas_ui/src/components/topasso.vue
@@ -12,6 +12,20 @@
                         auto
                 ></v-select>
             </div>
+            <div v-if="showControls.indexOf('significant')>-1">
+                <h6 class="mt-4">Significance</h6>
+                <v-switch
+                        label="Only show significant hits"
+                        v-model="significant"
+                        primary
+                        class="mt-0 mb-0"
+                ></v-switch>
+                <div class="ml-3" v-if="significant">
+                    <v-radio label="Permutation threshold" v-model="filters.significant" value="p" class="mt-0 mb-0"></v-radio>
+                    <v-radio label="Bonferroni threshold" v-model="filters.significant" value="b" class="mt-0 mb-0"></v-radio>
+                </div>
+                <div>If turned off, all associations with p-value < 10<sup>-4</sup> will be displayed.</div>
+            </div>
             <div v-if="showControls.indexOf('maf')>-1">
                 <h6 class="mt-4">MAF</h6>
                 <v-checkbox v-model="filters.maf" primary :label="'<1% (' + roundPerc(percentage.maf['*-0.01']) + '% of associations)'" value="1" class="mb-0"></v-checkbox>
@@ -44,7 +58,7 @@
                 <v-checkbox v-model="filters.mac" primary :label="'≤5 (' + roundPerc(percentage.mac['*-6.0']) + '% of associations)'" value="0" class="mb-0"></v-checkbox>
                 <v-checkbox v-model="filters.mac" primary :label="'>5 (' + roundPerc(percentage.mac['6.0-*']) + '% of associations)'" value="5" class="mt-0"></v-checkbox>
             </div>
-            <div class="text-xs-center">
+            <div class="text-xs-center mb-3">
                 <h6 class="mt-4">Download</h6>
                 <div class="grey--text">Download the filtered associations (since the file first needs to be generated, this may take a while, please only click once)</div>
                 <v-btn floating primary class="mr-3 mt-2 btn--large" tag="a" :href="_getDownloadHref()" download v-tooltip:bottom="{html: 'Download set of filtered associations'}">
@@ -71,7 +85,7 @@
                     <tr :id="('snp' in props.item)? props.item.snp.chr + '_'+props.item.snp.position+'_' + props.item.study.id : 'missing_info'" >
                         <td v-if="hideFields.indexOf('name') == -1" @mouseover="showAssociation(props.item)">
                             <div v-if="'snp' in props.item" >{{ props.item.snp.chr | capitalize }}:{{ props.item.snp.position }}</div><div v-else >Missing SNP info</div></td>
-                        <td v-if="hideFields.indexOf('score') == -1" v-bind:class="['text-xs-right',{'blue--text' : props.item.overFDR}]" @mouseover="showAssociation(props.item)">{{ props.item.score | round }}</td>
+                        <td v-if="hideFields.indexOf('score') == -1" v-bind:class="['text-xs-right',{'blue--text' : props.item.overPermutation}]" @mouseover="showAssociation(props.item)">{{ props.item.score | round }}</td>
                         <td v-if="hideFields.indexOf('study') == -1" class="text-xs-right" @mouseover="showAssociation(props.item)">
                             <router-link :to="{name: 'studyDetail', params: { id: props.item.study.id }}" >{{ props.item.study.name }}</router-link></td>
                         <td v-if="hideFields.indexOf('gene') == -1" class="text-xs-right" @mouseover="showAssociation(props.item)">
@@ -122,7 +136,7 @@
                     <tr :id="('snp' in props.item)? props.item.snp.chr + '_'+props.item.snp.position+'_' + props.item.study.id : 'missing_info'" >
                         <td v-if="hideFields.indexOf('name') == -1" @mouseover="showAssociation(props.item)">
                             <div v-if="'snp' in props.item" >{{ props.item.snp.chr | capitalize }}:{{ props.item.snp.position }}</div><div v-else >Missing SNP info</div></td>
-                        <td v-if="hideFields.indexOf('score') == -1" v-bind:class="['text-xs-right',{'blue--text' : props.item.overFDR}]" @mouseover="showAssociation(props.item)">{{ props.item.score | round }}</td>
+                        <td v-if="hideFields.indexOf('score') == -1" v-bind:class="['text-xs-right',{'blue--text' : props.item.overPermutation}]" @mouseover="showAssociation(props.item)">{{ props.item.score | round }}</td>
                         <td v-if="hideFields.indexOf('study') == -1" class="text-xs-right" @mouseover="showAssociation(props.item)">
                             <router-link :to="{name: 'studyDetail', params: { id: props.item.study.id }}" >{{ props.item.study.name }}</router-link></td>
                         <td v-if="hideFields.indexOf('gene') == -1" class="text-xs-right" @mouseover="showAssociation(props.item)">
@@ -190,7 +204,21 @@
                         <v-checkbox v-model="filters.mac" primary :label="'<5 (' + roundPerc(percentage.mac['0-6']) + '% of associations)'" value="0" class="mb-0"></v-checkbox>
                         <v-checkbox v-model="filters.mac" primary :label="'>5 (' + roundPerc(percentage.mac['6-*']) + '% of associations)'" value="5" class="mt-0"></v-checkbox>
                     </div>
-                    <div class="text-xs-center">
+                    <div v-if="showControls.indexOf('significant')>-1">
+                        <h6 class="mt-2">Significance</h6>
+                        <v-switch
+                                label="Only show significant hits"
+                                v-model="significant"
+                                primary
+                                class="mt-0 mb-0"
+                        ></v-switch>
+                        <div class="ml-3" v-if="significant">
+                            <v-radio label="Permutation threshold" v-model="filters.significant" value="p" class="mt-0 mb-0"></v-radio>
+                            <v-radio label="Bonferroni threshold" v-model="filters.significant" value="b" class="mt-0 mb-0"></v-radio>
+                        </div>
+                        <div>If turned off, all associations with p-value < 10<sup>-4</sup> will be displayed.</div>
+                    </div>
+                    <div class="text-xs-center mb-3">
                         <h6 class="mt-4">Download</h6>
                         <div class="grey--text">Download the filtered associations (since the file first needs to be generated, this may take a while, please only click once)</div>
                         <v-btn floating primary class="mr-3 mt-2 btn--large" tag="a" :href="_getDownloadHref()" download v-tooltip:bottom="{html: 'Download set of filtered associations (since the file needs to be generated, this may take a while)'}">
@@ -202,7 +230,7 @@
                 <br>
                 <br>
                 <br>
-                <p class="text-xs-right"><v-switch v-model="showSwitch" primary label="Filters" class="mb-0 switch"></v-switch></p>
+                <p class="text-xs-right"><v-switch v-model="showSwitch" primary label="Filters" class="mb-0 switchright"></v-switch></p>
             </v-flex>
             </v-layout>
         </v-flex>
@@ -212,7 +240,7 @@
                     <br>
                     <br>
                     <br>
-                    <p class="text-xs-right"><v-switch v-model="showSwitch" primary label="Filters" class="mb-0 switch"></v-switch></p>
+                    <p class="text-xs-right"><v-switch v-model="showSwitch" primary label="Filters" class="mb-0 switchright"></v-switch></p>
                 </v-flex>
             </v-layout>
         </v-flex>
@@ -257,7 +285,7 @@
         @Prop()
         view: {name: "top-associations", phenotypeId: 0, studyId: 0, geneId: "1", zoom: 0, controlPosition: "left"};
         @Prop()
-        filters: {chr: string[], annotation: string[], maf: string[], mac: string[], type: string[]};
+        filters: {chr: string[], annotation: string[], maf: string[], mac: string[], type: string[], significant: string};
         @Prop({type: null})
         highlightedAssociations: Association[];
         localfilters : {};
@@ -285,6 +313,8 @@
         debouncedloadData = _.debounce(this.loadData, 300);
         selected = [];
         pageSizes = [25, 50, 75, 100, 200,];
+        significant = this.filters.significant !== "0";
+
 
 
         @Watch("currentPage")
@@ -311,6 +341,20 @@
         onTypeChanged(val: number, oldVal: number) {
             this.debouncedloadData(this.currentPage);
         }
+        @Watch("filters.significant")
+        onSignificantChanged(val: number, oldVal: number) {
+            this.debouncedloadData(this.currentPage);
+        }
+        @Watch("significant")
+        onSigChanged(val: boolean, oldVal: boolean) {
+            if(val){
+                this.filters.significant = "p";
+            }
+            else {
+                this.filters.significant = "0";
+            }
+        }
+
         @Watch("view.zoom")
         onZoomChanged(val: number, oldVal: number) {
             this.debouncedloadData(this.currentPage);
@@ -442,7 +486,7 @@ table.table tbody tr[active] {
         justify-content:center;
     }
 
-    .switch {
+    .switchright {
         transform: rotate(270deg);
     }
 </style>


### PR DESCRIPTION
Added a filtering for only significant hits option, with the choice between bonferroni or permutation-based thresholds. This change must only be merged once the associations have been redindexed in the server version of ES. Fixes #76