### PR TITLE
Fix REST API endpoint for top associations

### DIFF
--- a/aragwas_server/aragwas/settings/defaults.py
+++ b/aragwas_server/aragwas/settings/defaults.py
@@ -175,7 +175,7 @@ LOGGING = {
 }
 
 
-ES_HOSTNAME = os.environ.get('ELASTICSEARCH_HOSTNAME', 'http://elastic:changeme@localhost:9200')
+ES_HOSTNAME = os.environ.get('ELASTICSEARCH_HOSTNAME', 'localhost:9200')
 ES_USERNAME = os.environ.get('ELASTICSEARCH_USER', 'elastic')
 ES_PASSWORD = os.environ.get('ELASTICSEARCH_PASS', 'changeme')
 ES_HOST = 'http://%s:%s@%s' % (ES_USERNAME, ES_PASSWORD, ES_HOSTNAME)

--- a/aragwas_server/gwasdb/elastic.py
+++ b/aragwas_server/gwasdb/elastic.py
@@ -373,7 +373,7 @@ def load_filtered_top_associations(filters, start=0, size=50):
     associations = result['hits']['hits']
     return [association['_source'].to_dict() for association in associations], result['hits']['total']
 
-def load_filtered_top_associations_search_after(filters, search_after = ''):
+def load_filtered_top_associations_search_after(filters, search_after = '', limit=25):
     """Retrieves top associations and filter them through the tickable options"""
     s = Search(using=es, doc_type='associations')
     s = s.sort('-score', '_uid')
@@ -382,7 +382,7 @@ def load_filtered_top_associations_search_after(filters, search_after = ''):
         search_after = parse_lastel(search_after)
         print(search_after)
         s = s.extra(search_after=search_after)
-    s = s[0:25]
+    s = s[0:limit]
     print(json.dumps(s.to_dict()))
     result = s.execute()
     associations = result['hits']['hits']

--- a/aragwas_server/gwasdb/paginator.py
+++ b/aragwas_server/gwasdb/paginator.py
@@ -14,6 +14,9 @@ class EsPagination(pagination.LimitOffsetPagination):
         if (isinstance(data, dict)):
             d['lastel'] = data['lastel']
             d['results'] = data['results']
+            d['next'] += "?lastel=" + string(data['lastel'][0]) + "," + string(data['lastel'][1]) # f-strings could also work.
+            # One could also remove the automatically generated '&offset=XX' from the link to avoid confusion
+            d['previous'] = None
         else:
             d['results'] = data
         return Response(d)

--- a/aragwas_server/gwasdb/paginator.py
+++ b/aragwas_server/gwasdb/paginator.py
@@ -1,5 +1,6 @@
 from rest_framework import pagination
 from rest_framework.response import Response
+from rest_framework.utils.urls import replace_query_param
 
 class EsPagination(pagination.LimitOffsetPagination):
     default_limit = 25
@@ -13,8 +14,9 @@ class EsPagination(pagination.LimitOffsetPagination):
         }
         if (isinstance(data, dict)):
             d['lastel'] = data['lastel']
-            d['results'] = data['results']
-            d['next'] += "?lastel=" + string(data['lastel'][0]) + "," + string(data['lastel'][1]) # f-strings could also work.
+            d['results'] = data['results'] 
+            newLastEl = str(data['lastel'][0]) + "," + str(data['lastel'][1])
+            d['links']['next'] = replace_query_param(d['links']['next'],'lastel', newLastEl)
             # One could also remove the automatically generated '&offset=XX' from the link to avoid confusion
             d['previous'] = None
         else:
@@ -24,7 +26,7 @@ class EsPagination(pagination.LimitOffsetPagination):
 class CustomPagination(pagination.PageNumberPagination):
     def get_paginated_response(self, data):
         return Response({
-            'links': {
+            'links': {  
                 'next': self.get_next_link(),
                 'previous': self.get_previous_link()
             },

--- a/aragwas_server/gwasdb/rest.py
+++ b/aragwas_server/gwasdb/rest.py
@@ -477,7 +477,8 @@ class AssociationViewSet(EsViewSetMixin, viewsets.ViewSet):
         if len(filters['significant']) == 0:
             filters['significant'] = 'p'
         last_el = request.query_params.get('lastel', '')
-        associations, count, lastel = elastic.load_filtered_top_associations_search_after(filters,last_el)
+        limit = EsPagination().get_limit(request)
+        associations, count, lastel = elastic.load_filtered_top_associations_search_after(filters,last_el,limit)
         queryset = EsQuerySetLastEl(associations, count, lastel)
         # associations, count = elastic.load_filtered_top_associations(filters,offset,limit)
         # queryset = EsQuerySet(associations, count)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   backend:
     #image: "docker.artifactory.imp.ac.at/the1001genomes/aragwas:latest"
-    build: ./aragwas_server
+    build: .
     ports:
      - "8000:8000"
     entrypoint:


### PR DESCRIPTION
The links now contain the lastel query parameter to properly retrieve the next page.
